### PR TITLE
added references to methods with target object already bound

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ dependency-reduced-pom.xml
 .classpath
 .project
 .settings/
+.idea/
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,6 +3,9 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
+		<java.version>8</java.version>
 	</properties>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.gs</groupId>
@@ -18,6 +21,9 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
 				<version>2.4</version>
+				<configuration>
+					<createDependencyReducedPom>false</createDependencyReducedPom>
+				</configuration>
 				<executions>
 					<execution>
 						<phase>package</phase>
@@ -43,8 +49,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/com/gs/CallableMethodObject.java
+++ b/src/main/java/com/gs/CallableMethodObject.java
@@ -1,0 +1,42 @@
+package com.gs;
+
+import com.gs.CallableObject;
+import com.gs.GSVM;
+import com.gs.utils.Invoker;
+
+import java.lang.reflect.Method;
+
+public class CallableMethodObject extends CallableObject {
+    private final Object target;
+
+    public CallableMethodObject(Object obj, String name) {
+        super(name, 0, null);
+        this.target = obj;
+    }
+
+    public Object[] getCode() {
+        return new Object[]{};
+    }
+
+    public String toString() {
+        return "methref: " + target.getClass().getName() + "::" + name;
+    }
+
+    public Object call(GSVM vm, Object... args) throws Throwable {
+        // but if vm returns null, this means that we weren't there yet, so try to
+        // find matching function and remember it.
+        // First, create an array storing types of all arguments
+        Class<?>[] cls = new Class<?>[args == null ? 0 : args.length];
+        // and store types of arguments in it
+        for (int i = 0; i < (args == null ? 0 : args.length); ++i) {
+            if (args[i] == null) {
+                cls[i] = Object.class;
+            } else {
+                cls[i] = args[i].getClass();
+            }
+        }
+        // and try to find matching method
+        Method m = vm.getMethodFinder().findMethod(target.getClass(), name, cls);
+        return Invoker.getInvoker(m, args.length).invoke(target, args);
+    }
+}

--- a/src/main/java/com/gs/CallableObject.java
+++ b/src/main/java/com/gs/CallableObject.java
@@ -5,7 +5,7 @@ import java.io.PrintWriter;
 import com.gs.GSException;
 
 public class CallableObject {
-	String name;
+	protected String name;
 	int slotsCount;
 	int argsCount;
 	protected Object[] exec;
@@ -38,7 +38,7 @@ public class CallableObject {
 	}
 	// this puts args on the stack and calls using provided VM
 	// if called from vm, no arguments should be provided
-	public Object call(GSVM vm, Object... args) throws Exception {
+	public Object call(GSVM vm, Object... args) throws Throwable {
 		if (argsCount != args.length) {
 			throw new GSException("Function " + name
 				+ " called with invalid number of arguments: required: "
@@ -47,4 +47,3 @@ public class CallableObject {
 		return vm.run(this, new Object[this.slotsCount], args);
 	}
 }
-

--- a/src/main/java/com/gs/GSVM.java
+++ b/src/main/java/com/gs/GSVM.java
@@ -54,7 +54,7 @@ public final class GSVM {
 		prog = prog_stack.size() == 0 ? null : prog_stack.peek();
 	}
 
-	public void putGlobal(String name, Object var) throws Exception {
+	public void putGlobal(String name, Object var) throws Throwable {
 		globs.put(name, var);
 	}
 
@@ -69,7 +69,7 @@ public final class GSVM {
 		return globs.get(name);
 	}
 
-	public void putVar(int slot, Object var) throws Exception {
+	public void putVar(int slot, Object var) throws Throwable {
 		vars.peek()[slot] = var;
 	}
 
@@ -100,7 +100,7 @@ public final class GSVM {
 		methodFinder = new MethodFinder(mfp);
 	}
 
-	public Object run(CallableObject function, Object[] variables, Object... args) throws Exception {
+	public Object run(CallableObject function, Object[] variables, Object... args) throws Throwable {
 		pushCode(function.getCode());
 		pushVariablesVector(variables);
 		System.arraycopy(args, 0, variables, 0, args.length);

--- a/src/main/java/com/gs/LambdaObject.java
+++ b/src/main/java/com/gs/LambdaObject.java
@@ -19,7 +19,7 @@ public class LambdaObject extends CallableObject {
 	// this puts args on the stack and calls using provided VM
 	// if called from vm, no arguments should be provided
 	@Override
-	public Object call(GSVM vm, Object... args) throws Exception {
+	public Object call(GSVM vm, Object... args) throws Throwable {
 		if (argsCount != args.length) {
 			throw new GSException("Function " + name
 				+ " called with invalid number of arguments: required: "

--- a/src/main/java/com/gs/Runtime.java
+++ b/src/main/java/com/gs/Runtime.java
@@ -199,7 +199,7 @@ public class Runtime {
 	public CallableObject getFunction(String s) {
 		return callables.get(s);
 	}
-	public void put(String s, Object o) throws Exception {
+	public void put(String s, Object o) throws Throwable {
 		virtualMachine.putGlobal(s, o);
 	}
 	public GSVM getVM() {

--- a/src/main/java/com/gs/Script.java
+++ b/src/main/java/com/gs/Script.java
@@ -47,7 +47,7 @@ public class Script {
 		VAL_A, VAL_B, VAL_C;
 	}
 	private static boolean permanentRuntime = false;
-	private static Runtime getRuntime() throws Exception {
+	private static Runtime getRuntime() throws Throwable {
 		if (permanentRuntime == true && r != null) {
 			return r;
 		}
@@ -58,9 +58,9 @@ public class Script {
 			rt.put("io", new io());
 		}
 		rt.put("gs", new gs(r));
-		Constructor<Math> x = Math.class.getDeclaredConstructor();
-		x.setAccessible(true);
-		rt.put("math", x.newInstance());
+//		Constructor<Math> x = Math.class.getDeclaredConstructor();
+//		x.setAccessible(true);
+//		rt.put("math", x.newInstance());
 		rt.put("TestEnum", TestEnum.class);
 		stuff s = new stuff();
 		s.hmap.put(TestEnum.VAL_A, new HashMap<String, Object>());
@@ -158,7 +158,7 @@ public class Script {
 			"file with instruction dump for prog2.gs\n\n"
 		);
 	}
-	public static void main(String[] args) throws Exception {
+	public static void main(String[] args) throws Throwable {
 		int i = 0;
 		Runtime.CompilationOpts opts = new Runtime.CompilationOpts();
 		try {

--- a/src/main/java/com/gs/utils/CallableObjectInvoker.java
+++ b/src/main/java/com/gs/utils/CallableObjectInvoker.java
@@ -1,0 +1,17 @@
+package com.gs.utils;
+
+import com.gs.CallableObject;
+import com.gs.GSVM;
+
+public final class CallableObjectInvoker extends Invoker {
+    private final String name;
+    private final GSVM vm;
+    public CallableObjectInvoker(GSVM vm, String name) throws Throwable {
+        this.name = name;
+        this.vm = vm;
+    }
+    public final Object invoke(Object o, Object... objects) throws Throwable {
+        CallableObject co = (CallableObject)o.getClass().getField(name).get(o);
+        return co.call(vm, objects);
+    }
+}

--- a/src/main/java/com/gs/utils/CompoundAccessor.java
+++ b/src/main/java/com/gs/utils/CompoundAccessor.java
@@ -77,7 +77,7 @@ public final class CompoundAccessor implements IAccessor {
 		return "CMPA: " + object + ": " + designator;
 	}
 	@SuppressWarnings("unchecked")
-	public Object get() throws Exception {
+	public Object get() throws Throwable {
 		Class<?> fromCls = object.get().getClass();
 		if (fromCls.isArray()) {
 			return ArrayUtil.get(object.get(), ((Number)designator).intValue());
@@ -93,7 +93,7 @@ public final class CompoundAccessor implements IAccessor {
 		throw new RuntimeException("object " + object.get() + " [" + fromCls + "] is not an array or list");
 	}
 	@SuppressWarnings("unchecked")
-	public void set(Object o) throws Exception {
+	public void set(Object o) throws Throwable {
 		Class<?> fromCls = object.get().getClass();
 		if (fromCls.isArray()) {
 			ArrayUtil.set(object.get(), ((Number)designator).intValue(), o);
@@ -113,7 +113,7 @@ public final class CompoundAccessor implements IAccessor {
 		}
 		throw new RuntimeException("object " + object.get() + " [" + fromCls + "] is not an array, linkedlist nor abstractmap instance");
 	}
-	public Object invoke(Object[] args) throws Exception {
+	public Object invoke(Object[] args) throws Throwable {
 		CallableObject co = (CallableObject)get();
 		return co.call(vm, args);
 	}

--- a/src/main/java/com/gs/utils/ConstAccessor.java
+++ b/src/main/java/com/gs/utils/ConstAccessor.java
@@ -24,15 +24,15 @@ public final class ConstAccessor implements IAccessor {
 	public void release() {
 		pool.push(this);
 	}
-	public Object get() throws Exception {
+	public Object get() throws Throwable {
 		return value;
 	}
-	public void set(Object o) throws Exception {
+	public void set(Object o) {
 		throw new RuntimeException("Can't assign to constant.");
 	}
 	// Ok, if invoke was called, it was most probably immediate application of lambda or call
 	// of function returned from some other function.
-	public Object invoke(Object[] args) throws Exception {
+	public Object invoke(Object[] args) throws Throwable {
 		CallableObject co = (CallableObject)value;
 		return co.call(vm, args);
 	}

--- a/src/main/java/com/gs/utils/FieldAccessor.java
+++ b/src/main/java/com/gs/utils/FieldAccessor.java
@@ -1,13 +1,10 @@
 package com.gs.utils;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.util.ArrayDeque;
 
+import com.gs.CallableMethodObject;
 import com.gs.CallableObject;
 import com.gs.GSVM;
 
@@ -15,9 +12,12 @@ public final class FieldAccessor implements IAccessor {
 	protected IAccessor object;
 	protected String name;
 	protected GSVM vm;
+
 	private FieldAccessor() {
 	}
+
 	private static ArrayDeque<FieldAccessor> pool = new ArrayDeque<>();
+
 	public static FieldAccessor getFieldAccessor(GSVM vm, String name, IAccessor o) {
 		FieldAccessor fa = null;
 		if (pool.isEmpty()) {
@@ -30,10 +30,12 @@ public final class FieldAccessor implements IAccessor {
 		fa.object = o;
 		return fa;
 	}
+
 	public void release() {
 		object.release();
 		pool.push(this);
 	}
+
 	public static FieldAccessor getFieldAccessor(FieldAccessor fa) {
 		FieldAccessor acc = null;
 		if (pool.isEmpty()) {
@@ -46,105 +48,54 @@ public final class FieldAccessor implements IAccessor {
 		acc.object = fa.object;
 		return acc;
 	}
+
 	@Override
 	public String toString() {
 		return "FA: " + object + ": " + name;
 	}
-	public Object get() throws Exception {
+
+	public Object get() throws Throwable {
 		Object o = object.get();
-		if (o instanceof Class<?> && ((Class<?>)o).isEnum()) {
-			Class<?> cls = ((Class<?>) o); 
-			for(Object x: cls.getEnumConstants()) {
-				if (((Enum<?>)x).name().equals(name)) {
+		if (o instanceof Class<?> && ((Class<?>) o).isEnum()) {
+			Class<?> cls = ((Class<?>) o);
+			for (Object x : cls.getEnumConstants()) {
+				if (((Enum<?>) x).name().equals(name)) {
 					return x;
 				}
 			}
 		}
 		if (o.getClass().isArray()) {
 			if (name.equals("length")) {
-				return ((Object[])o).length;
+				return ((Object[]) o).length;
 			}
 		}
-		Field field = o.getClass().getField(name);
-		return field.get(object.get());
+		Field[] fields = o.getClass().getDeclaredFields();
+		for (Field f : fields) {
+			if (f.getName().equals(name)) {
+				return f.get(object.get());
+			}
+		}
+		for (Method m : o.getClass().getMethods()) {
+			if (m.getName().equals(name)) {
+				return new CallableMethodObject(o, name);
+			}
+		}
+		throw new RuntimeException("NOT A FIELD OR METHOD");
 	}
-	public void set(Object o) throws Exception {
-		Field field = ((Object)object.get()).getClass().getField(name);
+
+	public void set(Object o) throws Throwable {
+		Field field = ((Object) object.get()).getClass().getField(name);
 		field.set(object.get(), o);
 	}
-	public static abstract class Invoker {
-		abstract Object invoke(Object o, Object...objects) throws Throwable;
-		protected MethodHandle mh = null;
-		protected Method m = null;
-		protected Invoker() { }
-		protected Invoker(Method m) throws IllegalAccessException {
-			mh = MethodHandles.lookup().unreflect(m);
-			this.m = m;
-		}
-		public static final Invoker getInvoker(GSVM vm, String name) throws Throwable {
-			return new CallableObjectInvoker(vm, name);
-		}
-		public static final Invoker getInvoker(Method m, int paramCount) throws IllegalAccessException {
-			try {
-			if (Modifier.isStatic(m.getModifiers())) {
-				return new StaticInvoker(m, paramCount);
-			}
-			return new VirtualInvoker(m, paramCount);
-			} catch (Exception e) {
-				System.err.println(m);
-				throw e;
-			}
-		}
-		public String toString() {
-			return this.getClass() + " MH: " + mh + " M: " + m;
-		}
-	}
-	public static final class CallableObjectInvoker extends Invoker {
-		private final String name;
-		private final GSVM vm;
-		public CallableObjectInvoker(GSVM vm, String name) throws Throwable {
-			this.name = name;
-			this.vm = vm;
-		}
-		public final Object invoke(Object o, Object... objects) throws Throwable {
-			CallableObject co = (CallableObject)o.getClass().getField(name).get(o);
-			return co.call(vm, objects);
-		}
-	}
-	public static final class StaticInvoker extends Invoker {
-		private final MethodHandle mh2;
-		public StaticInvoker(Method m, int paramCount) throws IllegalAccessException {
-			super(m);
-			MethodType invocationType = MethodType.genericMethodType(paramCount);
-			mh = mh.asType(invocationType);
-			mh2 = MethodHandles.spreadInvoker(invocationType, 0);
-		}
-		@Override
-		public final Object invoke(Object o, Object... objects) throws Throwable {
-			return mh2.invokeExact(mh, objects);
-		}
-	}
-	public static final class VirtualInvoker extends Invoker {
-		private final MethodHandle mh2;
-		public VirtualInvoker(Method m, int paramCount) throws IllegalAccessException {
-			super(m);
-			MethodType invocationType = MethodType.genericMethodType(1 + paramCount);
-			mh = mh.asType(invocationType);
-			mh2 = MethodHandles.spreadInvoker(invocationType, 1);
-		}
-		@Override
-		public final Object invoke(Object o, Object... objects) throws Throwable {
-			return mh2.invokeExact(mh, o, objects);
-		}
-	}
+
 	public Object invoke(Object[] args) throws Throwable {
 //		System.out.println("INVOKING WITH ARGS: ");
 //		for (Object o: args) {
 //			System.out.println(o.getClass());
 //		}
-		Object target = (Object)object.get();
+		Object target = (Object) object.get();
 		// Try to recall remembered invoker.
-		Invoker invoker = (Invoker)vm.recall();
+		Invoker invoker = (Invoker) vm.recall();
 		// If it succeeded, try to invoke() it
 		if (invoker != null) {
 			try {
@@ -160,7 +111,7 @@ public final class FieldAccessor implements IAccessor {
 		// First, create an array storing types of all arguments
 		Class<?>[] cls = new Class<?>[args == null ? 0 : args.length];
 		// and store types of arguments in it
-		for (int i = 0 ; i < (args == null ? 0 : args.length) ; ++i) {
+		for (int i = 0; i < (args == null ? 0 : args.length); ++i) {
 			if (args[i] == null) {
 				cls[i] = Object.class;
 			} else {
@@ -173,13 +124,14 @@ public final class FieldAccessor implements IAccessor {
 		// If it is instance of CallableObject, create invoker and memoize it
 		if (m == null) {
 			@SuppressWarnings("unused") // this is here so we can use Java's mechanism for checking if it is instance of CallableObject
-			CallableObject co = (CallableObject)target.getClass().getField(name).get(target);
+					CallableObject co = (CallableObject) target.getClass().getField(name).get(target);
 			vm.memoize(Invoker.getInvoker(vm, name));
 		} else {
 			vm.memoize(Invoker.getInvoker(m, args.length));
 		}
-		invoker = (Invoker)vm.recall();
+		invoker = (Invoker) vm.recall();
 		return invoker.invoke(target, args);
 	}
+
 }
 

--- a/src/main/java/com/gs/utils/IAccessor.java
+++ b/src/main/java/com/gs/utils/IAccessor.java
@@ -1,8 +1,8 @@
 package com.gs.utils;
 
 public interface IAccessor {
-	public Object get() throws Exception;
-	public void set(Object o) throws Exception;
+	public Object get() throws Throwable;
+	public void set(Object o) throws Throwable;
 	public Object invoke(Object[] args) throws Throwable;
 	public void release();
 }

--- a/src/main/java/com/gs/utils/Invoker.java
+++ b/src/main/java/com/gs/utils/Invoker.java
@@ -1,0 +1,36 @@
+package com.gs.utils;
+
+import com.gs.GSVM;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+public abstract class Invoker {
+    public abstract Object invoke(Object o, Object... objects) throws Throwable;
+    protected MethodHandle mh = null;
+    protected Method m = null;
+    protected Invoker() { }
+    protected Invoker(Method m) throws IllegalAccessException {
+        mh = MethodHandles.lookup().unreflect(m);
+        this.m = m;
+    }
+    public static final Invoker getInvoker(GSVM vm, String name) throws Throwable {
+        return new CallableObjectInvoker(vm, name);
+    }
+    public static final Invoker getInvoker(Method m, int paramCount) throws IllegalAccessException {
+        try {
+        if (Modifier.isStatic(m.getModifiers())) {
+            return new StaticInvoker(m, paramCount);
+        }
+        return new VirtualInvoker(m, paramCount);
+        } catch (Exception e) {
+            System.err.println(m);
+            throw e;
+        }
+    }
+    public String toString() {
+        return this.getClass() + " MH: " + mh + " M: " + m;
+    }
+}

--- a/src/main/java/com/gs/utils/StaticInvoker.java
+++ b/src/main/java/com/gs/utils/StaticInvoker.java
@@ -1,0 +1,20 @@
+package com.gs.utils;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
+
+public final class StaticInvoker extends Invoker {
+    private final MethodHandle mh2;
+    public StaticInvoker(Method m, int paramCount) throws IllegalAccessException {
+        super(m);
+        MethodType invocationType = MethodType.genericMethodType(paramCount);
+        mh = mh.asType(invocationType);
+        mh2 = MethodHandles.spreadInvoker(invocationType, 0);
+    }
+    @Override
+    public final Object invoke(Object o, Object... objects) throws Throwable {
+        return mh2.invokeExact(mh, objects);
+    }
+}

--- a/src/main/java/com/gs/utils/VMCombinator.java
+++ b/src/main/java/com/gs/utils/VMCombinator.java
@@ -3,7 +3,7 @@ package com.gs.utils;
 import java.util.ArrayDeque;
 
 public abstract class VMCombinator {
-	public static final VMPair fetch(ArrayDeque<Object> s) throws Exception {
+	public static final VMPair fetch(ArrayDeque<Object> s) throws Throwable {
 		IAccessor acc1 = null;
 		IAccessor acc2 = null;
 		Object r = (acc1 = ((IAccessor)s.pop())).get();
@@ -12,7 +12,7 @@ public abstract class VMCombinator {
 		acc2.release();
 		return new VMPair(l, r);
 	}
-	public Object Combine(ArrayDeque<Object> s) throws Exception {
+	public Object Combine(ArrayDeque<Object> s) throws Throwable {
 		VMPair p = fetch(s);
 		if (p.l instanceof String || p.r instanceof String) {
 			return Combine(p.l.toString(), p.r.toString());
@@ -29,7 +29,7 @@ public abstract class VMCombinator {
 	public abstract Long Combine(Long l, Long r);
 	public abstract Double Combine(Double l, Double r);
 
-	public String Combine(String l, String r) throws Exception {
+	public String Combine(String l, String r) throws Throwable {
 		throw new RuntimeException("Combinator not defined for strings");
 	}
 	public static final VMCombinator ADD = new VMCombinator() {

--- a/src/main/java/com/gs/utils/VMCompare.java
+++ b/src/main/java/com/gs/utils/VMCompare.java
@@ -3,11 +3,11 @@ package com.gs.utils;
 import java.util.ArrayDeque;
 
 public class VMCompare {
-	public int Compare(ArrayDeque<Object> s) throws Exception {
+	public int Compare(ArrayDeque<Object> s) throws Throwable {
 		VMPair p = fetch(s);
 		return Compare(p.l, p.r);
 	}
-	public VMPair fetch(ArrayDeque<Object> s) throws Exception {
+	public VMPair fetch(ArrayDeque<Object> s) throws Throwable {
 		IAccessor acc1 = ((IAccessor)s.pop());
 		IAccessor acc2 = ((IAccessor)s.pop());
 		Object r = acc1.get();
@@ -17,7 +17,7 @@ public class VMCompare {
 		return new VMPair(l, r);
 	}
 	@SuppressWarnings("unchecked")
-	public int Compare(Object l, Object r) throws Exception {
+	public int Compare(Object l, Object r) throws Throwable {
 		if (l instanceof Number && r instanceof Number) {
 			double lhs = ((Number)l).doubleValue();
 			double rhs = ((Number)r).doubleValue();
@@ -30,7 +30,7 @@ public class VMCompare {
 	}
 	public static final VMCompare EQUAL = new VMCompare() {
 		@SuppressWarnings("unchecked")
-		public int Compare(ArrayDeque<Object> s) throws Exception {
+		public int Compare(ArrayDeque<Object> s) throws Throwable {
 			VMPair p = fetch(s);
 			if (p.l == null || p.r == null) {
 				if (p.l == null && p.r == null) {

--- a/src/main/java/com/gs/utils/VarAccessor.java
+++ b/src/main/java/com/gs/utils/VarAccessor.java
@@ -24,13 +24,13 @@ public final class VarAccessor implements IAccessor {
 	public void release() {
 		pool.push(this);
 	}
-	public Object get() throws Exception {
+	public Object get() throws Throwable {
 		return vm.getVar(name);
 	}
-	public void set(Object o) throws Exception {
+	public void set(Object o) throws Throwable {
 		vm.putVar(name, o);
 	}
-	public Object invoke(Object[] args) throws Exception {
+	public Object invoke(Object[] args) throws Throwable {
 		CallableObject co = (CallableObject)vm.getVar(name);
 		return co.call(vm, args);
 	}

--- a/src/main/java/com/gs/utils/VirtualInvoker.java
+++ b/src/main/java/com/gs/utils/VirtualInvoker.java
@@ -1,0 +1,20 @@
+package com.gs.utils;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
+
+public final class VirtualInvoker extends Invoker {
+    private final MethodHandle mh2;
+    public VirtualInvoker(Method m, int paramCount) throws IllegalAccessException {
+        super(m);
+        MethodType invocationType = MethodType.genericMethodType(1 + paramCount);
+        mh = mh.asType(invocationType);
+        mh2 = MethodHandles.spreadInvoker(invocationType, 1);
+    }
+    @Override
+    public final Object invoke(Object o, Object... objects) throws Throwable {
+        return mh2.invokeExact(mh, o, objects);
+    }
+}


### PR DESCRIPTION
Added ability to do the following:
def main() {
    def p = io.format;
    p("%\n", main);
}

So basically ability to create references to Java methods - note, that target object is already bound, so it is not possible to call same method (format) on different "io" object - not that there is any other, but still.

Also it is possible to return this value:

$ bin/gsr 'def main() { return io.format; }'
RUNNING PROGRAM FROM COMMANDLINE
methref: com.gs.Script$io::format
